### PR TITLE
Add initial support for Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ npm run start
 
 6. **HTML Output Generation**: For each input file, the TxtToHTML CLI tool creates a single.html file. For instance, using the tool to build a new 'bhavik.html' file from a 'bhavik.txt' file. The HTML5 standard is followed by the files that are created.
 
+7. **Conversion from `.md` to `.html` File**: When a user inputs `.md` file, TxtToHTML CLI tool will convert it to `.html` and store the generated file in the output directory.
+
 ## Usage
 
 1. The basic command is:
@@ -98,6 +100,12 @@ node src/index.js document.txt --output custom
 ```bash
 node src/index.js -o custom document
 node src/index.js --output custom document
+```
+
+9. The command which takes `.md` file and convert it to `.html` file and store it in `./til` directory.
+
+```bash
+node src/index.js document.md
 ```
 
 ## Example

--- a/examples/SpringBoot.txt
+++ b/examples/SpringBoot.txt
@@ -15,4 +15,3 @@ Automatically configure Spring and 3rd party libraries whenever possible
 Provide production-ready features such as metrics, health checks, and externalized configuration
 
 Absolutely no code generation and no requirement for XML configuration
-

--- a/examples/testing.md
+++ b/examples/testing.md
@@ -1,0 +1,15 @@
+# Heading 1
+
+## Heading 2
+
+first paragraph from md file
+
+second paragraph from md file
+
+third paragraph from md file
+
+*Italic font*
+
+**Bold font**
+
+Please follow this [Link]("https://commonmark.org/help/) for more information.

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const fs = require("fs"); // File system module for file operations
 const path = require("path"); // Path module for working with file paths
 const yargs = require("yargs"); // Yargs module for command-line argument parsing
 const mkdirp = require("mkdirp"); // mkdirp module for creating directories recursively
-const { processTextFile, processFolder } = require("./utils"); // Custom utility functions
+const { processTextFile, processFolder, processMdFile} = require("./utils"); // Custom utility functions
 
 // Define the version of the tool
 const version = "1.0.0";
@@ -70,7 +70,12 @@ function main() {
     // If the input is a .txt file, convert it to an HTML file
     processTextFile(inputPath, outputDir);
     console.log(`The Text file "${inputPath}" is converted into an HTML file.`);
-  } else {
+  } else if (inputPath.endsWith(".md")) {
+    // If the input is a .md file, convert it to an HTML file
+    processMdFile(inputPath, outputDir);
+    console.log(`The md file "${inputPath}" is converted into an HTML file.`);
+  }
+  else {
     console.error("Error: Invalid input file or directory.");
     process.exit(1);
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -68,8 +68,44 @@ function processFolder(inputDir, outputDir) {
   }
 }
 
+function processMdFile(inputFilePath, outputDir) {
+  const inputFileContent = fs.readFileSync(inputFilePath, "utf-8");
+
+  const paragraphs = inputFileContent
+      .replace(/^#\s(.+)$/gm, '<h1>$1</h1>') // heading 1
+      .replace(/^##\s(.+)$/gm, '<h2>$1</h2>') // heading 2
+      .replace(/^(?!<h[1-6]>|<ul>|<ol>|<li>|<a>).+$/gm, '<p>$&</p>') // paragraph
+      .replace(/\[(.+?)\]\((.+?)\)/g, '<a href=$2">$1</a>') //  link
+      .replace(/\*(.*?)\*/g, '<i>$1</i>') // italic
+      .replace(/\*\*(.*?)\*\*/g, '<b>$1</b>') // bold
+
+  const fileName = path.basename(inputFilePath, ".md");
+  const outputFile = path.join(outputDir, `${fileName}.html`);
+  mkdirp.sync(outputDir);
+
+  // Generate the HTML content with the extracted paragraphs
+  const htmlContent = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>${fileName}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" 
+        rel="stylesheet" 
+        integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" 
+        crossorigin="anonymous">
+</head>
+<body>
+${paragraphs}
+</body>
+</html>`;
+
+  fs.writeFileSync(outputFile, htmlContent);
+}
+
 // Export the functions for use in other modules
 module.exports = {
   processTextFile,
   processFolder,
+  processMdFile
 };


### PR DESCRIPTION
Fixes #9 

- I've added a new method in `src/utils.js` that enables the conversion of `.md `files to `.html` files using regex and `.replace`. This makes the code concise and easy to understand.
- Updated `README.md` file to include a new feature. New feature includes information about Markdown and how to use this new feature.